### PR TITLE
Add GitHub Action workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,31 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v2
+        with:
+          java-version: '21'
+
+      - name: Build with Maven
+        run: ./mvnw clean install
+
+      - name: Build Docker image
+        run: docker build -t spring-boot-webapp .
+
+      - name: Run unit tests
+        run: docker run --rm spring-boot-webapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Use eclipse-temurin:21-jdk as the base image
+FROM eclipse-temurin:21-jdk
+
+# Copy the application JAR file to the container
+COPY target/demo-0.0.1-SNAPSHOT.jar /app/demo.jar
+
+# Set the entry point to run the JAR file
+ENTRYPOINT ["java", "-jar", "/app/demo.jar"]


### PR DESCRIPTION
Fixes #2

Add GitHub Action workflow to build Docker container and run unit tests.

* **Dockerfile**
  - Use `eclipse-temurin:21-jdk` as the base image
  - Copy the application JAR file to the container
  - Set the entry point to run the JAR file

* **.github/workflows/build-and-test.yml**
  - Define a GitHub Actions workflow to build and test the application
  - Use `actions/checkout@v2` to check out the repository
  - Set up JDK 21 using `actions/setup-java@v2`
  - Build the application using Maven
  - Build the Docker image and run the unit tests

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/schdief/spring-boot-webapp/issues/2?shareId=1a8c0470-5e42-4fd4-900d-0dbe40ab5d04).