### PR TITLE
Add endpoint to create GitHub organization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>1.123</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/demo/controller/GitHubController.java
+++ b/src/main/java/com/example/demo/controller/GitHubController.java
@@ -1,0 +1,37 @@
+package com.example.demo.controller;
+
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GHCreateRepositoryBuilder;
+import org.kohsuke.github.GHOrganization;
+import org.kohsuke.github.GHRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RestController
+public class GitHubController {
+
+    @Value("${github.token}")
+    private String gitHubToken;
+
+    @PostMapping("/create-org")
+    public String createOrganization(@RequestBody Map<String, String> request) {
+        String orgName = request.get("orgName");
+        String repoName = request.get("repoName");
+
+        try {
+            GitHub github = GitHub.connectUsingOAuth(gitHubToken);
+            GHOrganization organization = github.createOrganization(orgName);
+            GHCreateRepositoryBuilder builder = organization.createRepository(repoName);
+            GHRepository repository = builder.create();
+            return "Organization and repository created successfully: " + repository.getHtmlUrl();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "Failed to create organization and repository: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=8080
+github.token=your_github_personal_access_token

--- a/src/test/java/com/example/demo/controller/GitHubControllerTest.java
+++ b/src/test/java/com/example/demo/controller/GitHubControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.demo.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class GitHubControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testCreateOrganization() throws Exception {
+        String requestBody = "{\"orgName\": \"test-org\", \"repoName\": \"test-repo\"}";
+
+        MvcResult result = mockMvc.perform(post("/create-org")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Organization and repository created successfully: https://github.com/test-org/test-repo"))
+                .andReturn();
+    }
+}

--- a/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -1,0 +1,3 @@
+/workspaces/spring-boot-webapp/src/main/java/com/example/demo/DemoApplication.java
+/workspaces/spring-boot-webapp/src/main/java/com/example/demo/controller/GitHubController.java
+/workspaces/spring-boot-webapp/src/main/java/com/example/demo/controller/HelloController.java


### PR DESCRIPTION
Fixes #5

Add endpoint to create a GitHub organization.

* Add dependency for `org.kohsuke:github-api:1.123` in `pom.xml` to integrate with GitHub API.
* Add property `github.token` in `src/main/resources/application.properties` to store GitHub personal access token.
* Create `GitHubController` class in `src/main/java/com/example/demo/controller/GitHubController.java` with a method `createOrganization` to handle POST requests to `/create-org` and forward the request to GitHub API to create a new organization and repository.
* Add `GitHubControllerTest` class in `src/test/java/com/example/demo/controller/GitHubControllerTest.java` with a test method `testCreateOrganization` to test the `/create-org` endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/schdief/spring-boot-webapp/issues/5?shareId=696ab2f0-ee74-4e9a-998f-e98fd39db9f3).